### PR TITLE
 50-migrate-to-pydantic-v2 

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -1,0 +1,20 @@
+# Release Notes
+
+## 0.14.0
+
+### Upgrades
+
+* Make package compatible with pydantic V2
+
+### Refactoring
+
+* Use an import trick to still use pydantic V1 even on environments using pydantic V2
+* Centralized pydantic import into base.py in order to avoid having to use import trick on multiple files
+
+### Docs
+
+* Updated readme to better reflect current state of the pacakge.
+* Started a changelog ! :champagne:
+* Major change in the doc 
+
+## M.m-1.p

--- a/changelog.md
+++ b/changelog.md
@@ -11,10 +11,8 @@
 * Use an import trick to still use pydantic V1 even on environments using pydantic V2
 * Centralized pydantic import into base.py in order to avoid having to use import trick on multiple files
 
-### Docs
+### Documentation
 
 * Updated readme to better reflect current state of the pacakge.
 * Started a changelog ! :champagne:
 * Major change in the doc 
-
-## M.m-1.p

--- a/monggregate/__init__.py
+++ b/monggregate/__init__.py
@@ -3,7 +3,7 @@
 from monggregate.pipeline import Pipeline
 from monggregate.expressions.expressions import Expression
 
-__version__ = "0.13.0"
+__version__ = "0.14.0"
 __author__ = "Vianney Mixtur"
 __contact__ = "prenom.nom@outlook.fr"
 __copyright__ = "Copyright © 2022 Vianney Mixtur"

--- a/monggregate/base.py
+++ b/monggregate/base.py
@@ -9,9 +9,9 @@ from typing import Any
 # ---------------------------
 import pydantic
 if pydantic.__version__.startswith("1"):
-    from pydantic import BaseModel as PydanticBaseModel, BaseConfig, Field, validator
+    from pydantic import BaseModel as PydanticBaseModel, BaseConfig, ValidationError, Field, validator
 else:
-    from pydantic.v1 import BaseModel as PydanticBaseModel, BaseConfig, Field, validator
+    from pydantic.v1 import BaseModel as PydanticBaseModel, BaseConfig, ValidationError, Field, validator
     
 from humps import camelize
 

--- a/monggregate/base.py
+++ b/monggregate/base.py
@@ -7,7 +7,12 @@ from typing import Any
 
 # 3rd Party imports
 # ---------------------------
-from pydantic import BaseModel as PydanticBaseModel, BaseConfig
+import pydantic
+if pydantic.__version__.startswith("1"):
+    from pydantic import BaseModel as PydanticBaseModel, BaseConfig, Field, validator
+else:
+    from pydantic.v1 import BaseModel as PydanticBaseModel, BaseConfig, Field, validator
+    
 from humps import camelize
 
 class BaseModel(PydanticBaseModel, ABC):

--- a/monggregate/expressions/expressions.py
+++ b/monggregate/expressions/expressions.py
@@ -10,7 +10,7 @@ from typing import Any, Literal
 
 # 3rd Party imports
 # ---------------------------
-from pydantic import validator
+from monggregate.base import validator
 
 # Local imports
 # ----------------------------

--- a/monggregate/expressions/expressions.py
+++ b/monggregate/expressions/expressions.py
@@ -67,11 +67,11 @@ class Expression(BaseModel):
     Expressions can be nested.
     """
 
-    constant : int | float | str | bool | None
-    field : FieldPath | None
-    variable : Variable | None
+    constant : int | float | str | bool | None = None
+    field : FieldPath | None = None
+    variable : Variable | None = None
 
-    content : Content | None
+    content : Content | None = None
 
     @validator("variable", pre=True, always=True)
     @classmethod

--- a/monggregate/expressions/fields.py
+++ b/monggregate/expressions/fields.py
@@ -6,7 +6,11 @@ import re
 
 # 3rd Party imports
 # -------------------------------------------
-from pydantic import ConstrainedStr
+import pydantic
+if pydantic.__version__.startswith("1"):
+    from pydantic import ConstrainedStr
+else:
+    from pydantic.v1.types import ConstrainedStr
 
 # Types definition
 # -------------------------------------------

--- a/monggregate/operators/array/filter.py
+++ b/monggregate/operators/array/filter.py
@@ -71,7 +71,7 @@ class Filter(ArrayOperator):
     expression : Any =  Field(alias="input")
     query : Any = Field(alias="cond")
     let : str | None = Field("this", alias="as")
-    limit : int | None = Field(ge=1) # NOTE : limit can actually be an expression but constraints are  invalid with any type
+    limit : int | None = Field(None, ge=1) # NOTE : limit can actually be an expression but constraints are  invalid with any type
 
     @property
     def statement(self) -> dict:

--- a/monggregate/operators/array/filter.py
+++ b/monggregate/operators/array/filter.py
@@ -42,8 +42,8 @@ $filter has the following syntax:
           $filter returns all matching array elements.
 """
 
-from pydantic import validator, Field
 from typing import Any
+from monggregate.base import Field
 from monggregate.operators.array.array import ArrayOperator
 
 class Filter(ArrayOperator):

--- a/monggregate/operators/array/max_n.py
+++ b/monggregate/operators/array/max_n.py
@@ -44,8 +44,8 @@ Behavior
 
 """
 
-from pydantic import Field
 from typing import Any
+from monggregate.base import Field
 from monggregate.operators.array.array import ArrayOperator
 
 class MaxN(ArrayOperator):

--- a/monggregate/operators/array/min_n.py
+++ b/monggregate/operators/array/min_n.py
@@ -44,8 +44,8 @@ Behavior
 
 """
 
-from pydantic import Field
 from typing import Any
+from monggregate.base import Field
 from monggregate.operators.array.array import ArrayOperator
 
 class MinN(ArrayOperator):

--- a/monggregate/operators/array/sort_array.py
+++ b/monggregate/operators/array/sort_array.py
@@ -81,9 +81,9 @@ $sortArray to use a particular sorting algorithm.
 
 """
 
-from typing import Literal
-from pydantic import Field
-from typing import Any
+from typing import Any, Literal
+
+from monggregate.base import Field
 from monggregate.operators.array.array import ArrayOperator
 
 class SortArray(ArrayOperator):

--- a/monggregate/pipeline.py
+++ b/monggregate/pipeline.py
@@ -95,8 +95,8 @@ class Pipeline(BaseModel): # pylint: disable=too-many-public-methods
     """
 
     stages : list[Stage] = []
-    _db : Database | None # necessary to execute the pipeline
-    collection : str | None
+    _db : Database | None = None# necessary to execute the pipeline
+    collection : str | None =None
     
 
     @property

--- a/monggregate/search/collectors/facet.py
+++ b/monggregate/search/collectors/facet.py
@@ -168,9 +168,7 @@ The following limitations apply:
 from datetime import datetime
 from typing import Literal
 
-from pydantic import validator
-
-from monggregate.base import BaseModel
+from monggregate.base import BaseModel, validator
 from monggregate.expressions.fields import FieldName
 from monggregate.search.collectors.collector import SearchCollector
 from monggregate.search.operators import(

--- a/monggregate/search/commons/count.py
+++ b/monggregate/search/commons/count.py
@@ -5,8 +5,8 @@ https://www.mongodb.com/docs/atlas/atlas-search/counting/#std-label-count-ref
 """
 
 from typing import Literal
-from pydantic import Field
-from monggregate.base import BaseModel
+
+from monggregate.base import BaseModel, Field
 
 class CountOptions(BaseModel):
     """Class defining the count parameters."""

--- a/monggregate/search/commons/fuzzy.py
+++ b/monggregate/search/commons/fuzzy.py
@@ -1,7 +1,6 @@
 """Module defining an interface to define the fuzzy search parameters."""
 
-from pydantic import Field
-from monggregate.base import BaseModel
+from monggregate.base import BaseModel, Field
 
 class FuzzyOptions(BaseModel):
     """Class defining the fuzzy search parameters."""

--- a/monggregate/search/commons/highlight.py
+++ b/monggregate/search/commons/highlight.py
@@ -5,8 +5,8 @@ https://www.mongodb.com/docs/atlas/atlas-search/highlighting/#syntax
 """
 
 from typing import Literal
-from pydantic import Field
-from monggregate.base import BaseModel
+
+from monggregate.base import BaseModel, Field
 
 class HighlightOptions(BaseModel):
     """Class defining the highlighting parameters."""

--- a/monggregate/search/operators/compound.py
+++ b/monggregate/search/operators/compound.py
@@ -59,7 +59,7 @@ such as autocomplete, text, or span, to specify query criteria.
 """
 from datetime import datetime
 from typing import Literal
-from pydantic import Field
+from monggregate.base import Field
 from monggregate.search.operators.operator import SearchOperator, Clause
 from monggregate.search.operators.clause import (
     Autocomplete,

--- a/monggregate/search/operators/more_like_this.py
+++ b/monggregate/search/operators/more_like_this.py
@@ -84,7 +84,7 @@ You can't use the moreLikeThis operator inside the embeddedDocument operator to 
 
 """
 
-from pydantic import validator
+from monggregate.base import validator
 from monggregate.search.operators.operator import SearchOperator
 
 

--- a/monggregate/search/operators/range.py
+++ b/monggregate/search/operators/range.py
@@ -68,7 +68,7 @@ score           object                  Modify the score assigned to matching   
 
 
 from datetime import datetime
-from pydantic import validator
+from monggregate.base import validator
 from monggregate.search.operators.operator import SearchOperator
 
 class Range(SearchOperator, smart_union=True):

--- a/monggregate/search/operators/range.py
+++ b/monggregate/search/operators/range.py
@@ -90,10 +90,10 @@ class Range(SearchOperator, smart_union=True):
     """
 
     path : str | list[str]
-    gt : int | float | datetime | None
-    lt : int | float | datetime | None
-    gte : int | float | datetime | None
-    lte : int | float | datetime | None
+    gt : int | float | datetime | None = None
+    lt : int | float | datetime | None = None
+    gte : int | float | datetime | None = None
+    lte : int | float | datetime | None = None
     score : dict|None
 
     @validator("gte", pre=True, always=True)

--- a/monggregate/search/operators/text.py
+++ b/monggregate/search/operators/text.py
@@ -66,9 +66,9 @@ class Text(SearchOperator):
 
     query : str|list[str]
     path : str | list[str]
-    fuzzy : dict | None
-    score : dict | None
-    synonyms : str | None
+    fuzzy : dict | None = None
+    score : dict | None = None
+    synonyms : str | None = None
 
     @property
     def statement(self) -> dict:

--- a/monggregate/search/operators/wildcard.py
+++ b/monggregate/search/operators/wildcard.py
@@ -89,7 +89,7 @@ class Wilcard(SearchOperator):
     query : str | list[str]
     path : str | list[str]
     allow_analyzed_field : bool = Field(False, alias="allowAnalyzedField")
-    score : dict | None
+    score : dict | None = None
 
     @property
     def statement(self) -> dict:

--- a/monggregate/search/operators/wildcard.py
+++ b/monggregate/search/operators/wildcard.py
@@ -65,7 +65,7 @@ EXAMPLE : To create a wildcard expression which searches for any string containi
 
 """
 
-from pydantic import Field
+from monggregate.base import Field
 from monggregate.search.operators.operator import SearchOperator
 
 class Wilcard(SearchOperator):

--- a/monggregate/stages/bucket.py
+++ b/monggregate/stages/bucket.py
@@ -100,8 +100,8 @@ class Bucket(Stage):
 
     by : Content = Field(...,alias="group_by")
     boundaries : Consts
-    default : Const | None
-    output : dict[FieldName, AccumulatorExpression] | None
+    default : Const | None = None
+    output : dict[FieldName, AccumulatorExpression] | None = None
 
     # Validators
     # ------------------------------

--- a/monggregate/stages/bucket.py
+++ b/monggregate/stages/bucket.py
@@ -49,8 +49,8 @@ $sort.
 
 """
 
-from typing import Any
-from pydantic import Field, validator
+
+from monggregate.base import Field, validator
 
 from monggregate.stages.stage import Stage
 from monggregate.expressions.content import Content, Const, Consts

--- a/monggregate/stages/bucket_auto.py
+++ b/monggregate/stages/bucket_auto.py
@@ -81,7 +81,7 @@ The values of the series are multiplied by a power of 10 when the groupBy values
 """
 
 from typing import Any
-from pydantic import Field, validator
+from monggregate.base import Field, validator
 from monggregate.stages.stage import Stage
 from monggregate.expressions.content import Content
 from monggregate.expressions.fields import FieldName

--- a/monggregate/stages/bucket_auto.py
+++ b/monggregate/stages/bucket_auto.py
@@ -139,8 +139,8 @@ class BucketAuto(Stage):
     # ----------------------------------------------------------------------------
     by : Content = Field(...,alias="group_by") # probably should restrict type to field_paths an operator expressions
     buckets : int = Field(..., gt=0)
-    output : dict[FieldName, AccumulatorExpression] | None # Accumulator Expressions #TODO : Define type and use it here
-    granularity : GranularityEnum | None
+    output : dict[FieldName, AccumulatorExpression] | None = None# Accumulator Expressions #TODO : Define type and use it here
+    granularity : GranularityEnum | None = None
 
 
     # Validators

--- a/monggregate/stages/group.py
+++ b/monggregate/stages/group.py
@@ -64,7 +64,7 @@ For more information, see $group Optimization.
 
 """
 from typing import Any
-from pydantic import Field, validator
+from monggregate.base import Field, validator
 from monggregate.stages.stage import Stage
 from monggregate.expressions.content import Content
 from monggregate.utils import validate_field_path

--- a/monggregate/stages/limit.py
+++ b/monggregate/stages/limit.py
@@ -48,7 +48,7 @@ See the following for more information on each:
 
 """
 
-from pydantic import Field
+from monggregate.base import Field
 from monggregate.stages.stage import Stage
 
 class Limit(Stage):

--- a/monggregate/stages/lookup.py
+++ b/monggregate/stages/lookup.py
@@ -245,7 +245,7 @@ For more information, see [$lookup Optimization](https://www.mongodb.com/docs/ma
 
 """
 
-from pydantic import Field, validator
+from monggregate.base import Field, validator
 from monggregate.stages.stage import Stage
 from monggregate.utils import StrEnum
 

--- a/monggregate/stages/out.py
+++ b/monggregate/stages/out.py
@@ -112,7 +112,7 @@ Restrictions
 
 """
 
-from pydantic import Field
+from monggregate.base import Field
 from monggregate.stages.stage import Stage
 
 class Out(Stage):

--- a/monggregate/stages/project.py
+++ b/monggregate/stages/project.py
@@ -144,9 +144,9 @@ class Project(Stage):
 
     """
 
-    include : list[str] | dict | bool | None
-    exclude : list[str] | dict | bool | None
-    fields : list[str] | None
+    include : list[str] | dict | bool | None = None
+    exclude : list[str] | dict | bool | None = None
+    fields : list[str] | None = None
     projection : dict = {}
 
     @validator("include", "exclude", pre=True, always=True)

--- a/monggregate/stages/project.py
+++ b/monggregate/stages/project.py
@@ -125,7 +125,7 @@ $projectstage. See Array Indexes are Unsupported.
 # NOTE : Would be nice and useful to have something keywords arguments based to generate the projection <VM, 16/09/2022>
 # (on top[on the side] of the below)
 
-from pydantic import validator
+from monggregate.base import validator
 from monggregate.stages.stage import Stage
 from monggregate.utils import to_unique_list
 

--- a/monggregate/stages/replace_root.py
+++ b/monggregate/stages/replace_root.py
@@ -65,7 +65,7 @@ Or, you can use $ifNullexpression to specify some other document to be root; for
 
 """
 
-from pydantic import Field, validator
+from monggregate.base import Field, validator
 from monggregate.stages.stage import Stage
 from monggregate.utils import validate_field_path
 

--- a/monggregate/stages/sample.py
+++ b/monggregate/stages/sample.py
@@ -49,7 +49,7 @@ If you are using the:
 
 """
 
-from pydantic import Field
+from monggregate.base import Field
 from monggregate.stages.stage import Stage
 
 class Sample(Stage):

--- a/monggregate/stages/search.py
+++ b/monggregate/stages/search.py
@@ -74,7 +74,8 @@ try:
     from typing import Self
 except ImportError:
     from typing_extensions import Self
-from pydantic import Field, validator
+    
+from monggregate.base import Field, validator
 from monggregate.stages.stage import Stage
 from monggregate.search.collectors import Facet, Facets
 from monggregate.search.operators import(

--- a/monggregate/stages/sort.py
+++ b/monggregate/stages/sort.py
@@ -129,9 +129,9 @@ class Sort(Stage):
 
     """
 
-    descending : list[str] | dict | bool | None
-    ascending  : list[str] | dict | bool | None
-    by : list[str] | None
+    descending : list[str] | dict | bool | None = None
+    ascending  : list[str] | dict | bool | None = None
+    by : list[str] | None = None
     query : dict[str, Literal[1, -1]] = {}
 
     # NOTE : The below are validators are very close to what is used for project => CONSIDER factorizing <VM, 27/10/2022>

--- a/monggregate/stages/sort.py
+++ b/monggregate/stages/sort.py
@@ -95,7 +95,7 @@ the returned sort order will always be the same across multiple executions of th
 """
 
 from typing import Literal
-from pydantic import validator
+from monggregate.base import validator
 from monggregate.stages.stage import Stage
 from monggregate.utils import to_unique_list
 

--- a/monggregate/stages/sort_by_count.py
+++ b/monggregate/stages/sort_by_count.py
@@ -47,7 +47,7 @@ $group + $sort sequence:
 
 """
 
-from pydantic import validator
+from monggregate.base import validator
 from monggregate.stages.stage import Stage
 from monggregate.utils import validate_field_path
 

--- a/monggregate/stages/union_with.py
+++ b/monggregate/stages/union_with.py
@@ -188,7 +188,7 @@ class UnionWith(Stage):
 
     collection : str = Field(alias="coll")
     # Find a way to better type pipeline while avoiding circular imports <VM, 18/06/2023>
-    pipeline : list[dict] | None
+    pipeline : list[dict] | None = None
 
     @validator("pipeline", pre=True, always=True)
     def validate_pipeline(cls, pipeline:Any):

--- a/monggregate/stages/union_with.py
+++ b/monggregate/stages/union_with.py
@@ -170,7 +170,7 @@ $merge              The $unionWith pipeline cannot include the $merge stage.
 """
 
 from typing import Any
-from pydantic import Field, validator
+from monggregate.base import Field, validator
 from monggregate.base import BaseModel
 from monggregate.stages.stage import Stage
 

--- a/monggregate/stages/unwind.py
+++ b/monggregate/stages/unwind.py
@@ -66,7 +66,7 @@ preserveNullAndEmptyArrays option.
 
 """
 
-from pydantic import Field, validator
+from monggregate.base import Field, validator
 from monggregate.stages.stage import Stage
 from monggregate.utils import validate_field_path
 

--- a/monggregate/stages/unwind.py
+++ b/monggregate/stages/unwind.py
@@ -87,7 +87,7 @@ class Unwind(Stage):
     # Attributes
     # ----------------------
     path_to_array : str = Field(..., alias = "path")
-    include_array_index : str | None #The name of a new field to hold the array index of the element.
+    include_array_index : str | None = None #The name of a new field to hold the array index of the element.
                                         # The name cannot start with a dollar sign $
     always: bool = Field(False, alias="preserve_null_and_empty_arrays")
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -6,7 +6,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "monggregate"
-version = "0.13.0"
+version = "0.14.0"
 description = "MongoDB aggregation pipelines made easy. Joins, grouping, counting and much more..."
 readme = "README.md"
 authors = [{ name = "Vianney Mixtur", email = "vianney.mixtur@outlook.fr" }]
@@ -35,7 +35,7 @@ dev = ["bumpver", "pytest", "mypy", "pylint"]
 Homepage = "https://github.com/VianneyMI/monggregate"
 
 [tool.bumpver]
-current_version = "0.13.0"
+current_version = "0.14.0"
 version_pattern = "MAJOR.MINOR.PATCH"
 commit_message = "bump version {old_version} -> {new_version}"
 commit = true

--- a/readme.md
+++ b/readme.md
@@ -1,6 +1,6 @@
 ## Overview
 
-Monggregate is a library that aims at simplifying usage of MongoDB aggregation pipeline in python.
+Monggregate is a library that aims at simplifying usage of MongoDB aggregation pipelines in python.
 It is based on MongoDB official python driver, pymongo and on [pydantic](https://pydantic-docs.helpmanual.io/).
 
 ### Features
@@ -9,6 +9,7 @@ It is based on MongoDB official python driver, pymongo and on [pydantic](https:/
 - provides an OOP interface to the aggregation pipeline.
 - allows you to focus on your requirements rather than MongoDB syntax
 - integrates all the MongoDB documentation and allows you to quickly refer to it without having to navigate to the website.
+- enables autocompletion on the various MongoDB features.
 - offers a pandas-style way to chain operations on data.
 
 ## Requirements
@@ -16,13 +17,6 @@ It is based on MongoDB official python driver, pymongo and on [pydantic](https:/
 This package requires python > 3.10, pydantic > 1.8.0
 
 ## Installation
-
-### Manually
-
-1. Download the repo from https://github.com/VianneyMI/mongreggate
-2. Copy the repo to your project
-3. Navigate to the folder containing the downloaded repo
-4. Install the repo locally by executing the following command: ` python -m pip install -e .`
 
 ### PIP
 
@@ -32,9 +26,51 @@ The repo is now available on PyPI:
 pip install monggregate
 ```
 
+### Manually
+
+1. Download the repo from https://github.com/VianneyMI/mongreggate
+2. Copy the repo to your project
+3. Navigate to the folder containing the downloaded repo
+4. Install the repo locally by executing the following command: ` python -m pip install -e .`
+
 ## Usage
 
-The below examples reference the  MongoDB sample_mflix database
+The below examples reference the MongoDB sample_mflix database
+
+### ... through the pipeline interface
+
+```python
+
+from dotenv import load_dotenv
+import pymongo
+from monggregate.pipeline import Pipeline
+
+# Load config from a .env file:
+load_dotenv(verbose=True)
+MONGODB_URI = os.environ["MONGODB_URI"]
+
+# Connect to your MongoDB cluster:
+client = pymongo.MongoClient(MONGODB_URI)
+
+# Get a reference to the "sample_mflix" database:
+db = client["sample_mflix"]
+
+# Creating the pipeline
+pipeline = Pipeline()
+
+pipeline.match(
+    title="A Star is Born"
+).sort(
+    value="year"
+).limit(
+    value=1
+)
+
+# Executing the pipeline
+db["movies"].aggregate(pipeline.export())
+
+```
+
 
 ### ... through the stage classes
 
@@ -82,88 +118,6 @@ results = move_collection.aggregate(pipeline)
 
 ```
 
-### ... through the pipeline inteface
-
-#### Approach #1
-
-```python
-
-from dotenv import load_dotenv
-import pymongo
-from monggregate.pipeline import Pipeline
-
-# Load config from a .env file:
-load_dotenv(verbose=True)
-MONGODB_URI = os.environ["MONGODB_URI"]
-
-# Connect to your MongoDB cluster:
-client = pymongo.MongoClient(MONGODB_URI)
-
-# Get a reference to the "sample_mflix" database:
-db = client["sample_mflix"]
-
-# Creating the pipeline
-pipeline = Pipeline(
-    collection="movies",
-)
-
-pipeline.match(
-    query = {
-        "title" : "A Star is Born"
-    }
-).sort(
-    query = {
-        "year":1
-    }
-).limit(
-    value=1
-)
-
-# Executing the pipeline
-db["movies"].aggregate(pipeline())
-
-```
-
-#### Approach #2
-
-```python
-
-from dotenv import load_dotenv
-import pymongo
-from monggregate.pipeline import Pipeline
-
-# Load config from a .env file:
-load_dotenv(verbose=True)
-MONGODB_URI = os.environ["MONGODB_URI"]
-
-# Connect to your MongoDB cluster:
-client = pymongo.MongoClient(MONGODB_URI)
-
-# Get a reference to the "sample_mflix" database:
-db = client["sample_mflix"]
-
-# Creating the pipeline
-pipeline = Pipeline(
-    _db=db,
-    on_call="run",
-    collection="movies",
-)
-
-pipeline.match(
-    query = {
-        "title" : "A Star is Born"
-    }
-).sort(
-    query = {
-        "year":1
-    }
-).limit(
-    value=1
-)
-
-# Executing the pipeline
-pipeline()
-```
 
 ## Motivation
 
@@ -174,11 +128,14 @@ With pymongo, which is the official MongoDB driver for python, there is no direc
 pymongo exposes an `aggregate` method but the pipeline inside is just a list of complex dictionaries that quickly become quite long, nested and overwhelming.
 
 At the end, it is barely readable for the one who built the pipeline. Let alone other developers.
-Besides, during the development process, it is often necessary to refer to the online documentation multiple times. Thus, the package aims at integrating the online document through the various docstrings of the classes and modules of the package.
+Besides, during the development process, it is often necessary to refer to the online documentation multiple times. Thus, the package aims at integrating the online documentation through in the docstrings of the various classes and modules of the package.
+Basically, the package mirrors every* stage and operator available on MongoDB.
+
+*Actually, it only covers a subset of the stages and operators available. Please come help me to increase the coverage. 
 
 ## Roadmap
 
-As of now, the package covers 33% of the available stages and barely 18% of the available operators.
+As of now, the package covers 50% of the available stages and 20% of the available operators.
 The goal is to quickly reach 100% of both stages and operators.
 The source code integrates most of the online MongoDB documentation. If the online documentation evolves, it will need to be updated here as well.
 The current documentation is not consistent throughout the package it will need to be standardized later on.

--- a/test/test_expressions.py
+++ b/test/test_expressions.py
@@ -3,8 +3,15 @@
 
 
 import pytest
-from pydantic import BaseModel, Field, ValidationError
-from pydantic.errors import StrRegexError
+import pydantic
+from monggregate.base import PydanticBaseModel, Field
+if pydantic.__version__.startswith("1"):
+    from pydantic import ValidationError
+    from pydantic.errors import StrRegexError
+else:
+    from pydantic.v1 import ValidationError
+    from pydantic.v1.errors import StrRegexError
+    
 from monggregate.stages.count import FieldName
 
 
@@ -15,7 +22,7 @@ def test_constraints_in_hybrid_types()->None:
     Ensures that constraints are taken into account for Union types, only for the relevant type of the Union.
     """
 
-    class Test(BaseModel):
+    class Test(PydanticBaseModel):
         """Test class with hybrid type"""
 
         x : int | dict = Field(gt=1)

--- a/test/test_search_operators.py
+++ b/test/test_search_operators.py
@@ -1,7 +1,7 @@
 """Module gathering the tests of the search operators"""
 
 import pytest
-from pydantic import ValidationError
+from monggregate.base import ValidationError
 from monggregate.search.operators import(
     Autocomplete,
     Equals,

--- a/test/test_stages.py
+++ b/test/test_stages.py
@@ -6,7 +6,7 @@ Checks that at least each stage can be instantiated properly.
 """
 
 import pytest
-from pydantic import ValidationError
+from monggregate.base import ValidationError
 
 from monggregate import Pipeline
 from monggregate.stages import( # pylint: disable=import-error


### PR DESCRIPTION
- Make package compatible with pydantic v2 while still being comptatible with pydantic V1
- Under the hood only pydantic V1 is actually used by the package and the V2 features are not exposed by the package